### PR TITLE
Fix black screen after long sleep

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -1566,6 +1566,36 @@
 				<key>Skip</key>
 				<integer>0</integer>
 			</dict>
+			<dict>
+				<key>Arch</key>
+				<string>Any</string>
+				<key>Base</key>
+				<string>__ZN8AppleRTC18setupDateTimeAlarmEPK11RTCDateTime</string>
+				<key>Comment</key>
+				<string>Disable RTC wake scheduling - Fix Black Screen on NRed</string>
+				<key>Count</key>
+				<integer>1</integer>
+				<key>Enabled</key>
+				<true/>
+				<key>Find</key>
+				<data></data>
+				<key>Identifier</key>
+				<string>com.apple.driver.AppleRTC</string>
+				<key>Limit</key>
+				<integer>0</integer>
+				<key>Mask</key>
+				<data></data>
+				<key>MaxKernel</key>
+				<string></string>
+				<key>MinKernel</key>
+				<string>19.0.0</string>
+				<key>Replace</key>
+				<data>ww==</data>
+				<key>ReplaceMask</key>
+				<data></data>
+				<key>Skip</key>
+				<integer>0</integer>
+			</dict>
 		</array>
 		<key>Quirks</key>
 		<dict>


### PR DESCRIPTION
- This will disable Darkwake in macOS which cause this issue
- Also your config plist + OpenCore version is outdated ( 0.8.8? ) ( I guess you are using OCAT and forgot to sync to the latest OC version, update it! )
## For more information, visit my repo: [M413IA](https://github.com/gorouflex/M413IA/)